### PR TITLE
fix: optimize the splicing method of serverEntry to make it compatible with bun

### DIFF
--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -109,7 +109,12 @@ export async function build(ssgOptions: Partial<ViteSSGOptions> = {}, viteConfig
 
   const prefix = (format === 'esm' && process.platform === 'win32') ? 'file://' : ''
   const ext = format === 'esm' ? '.mjs' : '.cjs'
-  const serverEntry = join(prefix, ssgOut, parse(ssrEntry).name + ext)
+
+  /**
+   * `join('file://')` will be equal to `'file:\'`, which is not the correct file protocol and will fail to be parsed under bun.
+   * It is changed to '+' splicing here.
+   */
+  const serverEntry = prefix + join(ssgOut, parse(ssrEntry).name + ext).replace(/\\/g, '/')
 
   const _require = createRequire(import.meta.url)
 


### PR DESCRIPTION
`join('file://')` will be equal to `'file:\'`, which is not the correct file protocol and will fail to be parsed under bun.
It is changed to '+' splicing here.