### PR TITLE
chore: update critters peerDep to 0.0.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "release": "bumpp && npm publish"
   },
   "peerDependencies": {
-    "critters": "^0.0.20",
+    "critters": "^0.0.22",
     "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0",
     "vue": "^3.2.10",
     "vue-router": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "release": "bumpp && npm publish"
   },
   "peerDependencies": {
-    "critters": "^0.0.22",
+    "critters": "^0.0.24",
     "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0",
     "vue": "^3.2.10",
     "vue-router": "^4.0.1"


### PR DESCRIPTION
Because `^` does not mean a range for versions starting with `0.0`, the version of critters needs to be bumped. Otherwise, users will get incompatible versions error.
https://github.com/npm/node-semver/blob/main/README.md#caret-ranges-123-025-004:~:text=In%20other%20words%2C%20this%20allows%20patch%20and%20minor%20updates%20for%20versions%201.0.0%20and%20above%2C%20patch%20updates%20for%20versions%200.X%20%3E%3D0.1.0%2C%20and%20no%20updates%20for%20versions%200.0.X

refs #119, #380
