### PR TITLE
fix(client): treeshake hydration

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -15,18 +15,17 @@ export function ViteSSG(
   App: Component,
   routerOptions: RouterOptions,
   fn?: (context: ViteSSGContext<true>) => Promise<void> | void,
-  options: ViteSSGClientOptions = {},
+  options?: ViteSSGClientOptions,
 ) {
   const {
     transformState,
     registerComponents = true,
     useHead = true,
     rootContainer = '#app',
-    hydration = false,
-  } = options
+  } = options ?? {}
 
   async function createApp(_client = false, routePath?: string) {
-    const app = import.meta.env.SSR || hydration
+    const app = import.meta.env.SSR || options?.hydration
       ? createSSRApp(App)
       : createClientApp(App)
 

--- a/src/client/single-page.ts
+++ b/src/client/single-page.ts
@@ -13,17 +13,17 @@ export * from '../types'
 export function ViteSSG(
   App: Component,
   fn?: (context: ViteSSGContext<false>) => Promise<void> | void,
-  options: ViteSSGClientOptions = {},
+  options?: ViteSSGClientOptions,
 ) {
   const {
     transformState,
     registerComponents = true,
     useHead = true,
     rootContainer = '#app',
-    hydration = false,
-  } = options
+  } = options ?? {}
+
   async function createApp(_client = false) {
-    const app = import.meta.env.SSR || hydration
+    const app = import.meta.env.SSR || options?.hydration
       ? createSSRApp(App)
       : createClientApp(App)
 


### PR DESCRIPTION
## Description

Treeshake hydration support as the feature (default to `false` and using `createSSRApp`) is not currently tree shaken and leads to extra 5Kb in client bundle size (check screenshots).

## Additional context

Rollup wasn't able to tree-shake because of :
1) Default options (`= {}`)
2) Default + destructure of treeshake value (`= false`)

## Bundle size diff

The difference is mainly (if not only) explained by `createSSRApp` import from `vue` that was previously shipped even if not used on client (`createSSRApp` is used on client when `hydration` is `true`)

### Before
![image](https://github.com/user-attachments/assets/2a555170-d626-428c-b2b0-5d816ea37400)


### After (`4.75Kb` ⬇️, `1.9Kb (gzip)` ⬇️)
![image](https://github.com/user-attachments/assets/23c3c6c0-8c58-43f0-a321-6e652565ede7)
