### PR TITLE
fix(dir-styles): use `join` instead `resolve` when using nested dir style

### DIFF
--- a/examples/multiple-pages-with-store/package.json
+++ b/examples/multiple-pages-with-store/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "dev": "DEBUG='vite-ssg:*' vite",
     "build": "DEBUG='vite-ssg:*' vite-ssg build",
+    "build:nested": "NESTED_PAGES=true DEBUG='vite-ssg:*' vite-ssg build",
     "serve": "vite preview"
   },
   "dependencies": {

--- a/examples/multiple-pages-with-store/vite.config.ts
+++ b/examples/multiple-pages-with-store/vite.config.ts
@@ -1,4 +1,5 @@
 import type { UserConfig } from 'vite'
+import process from 'node:process'
 import Vue from '@vitejs/plugin-vue'
 import Components from 'unplugin-vue-components/vite'
 import Markdown from 'unplugin-vue-markdown/vite'
@@ -24,6 +25,7 @@ const config: UserConfig = {
   ],
   ssgOptions: {
     script: 'async',
+    dirStyle: process.env.NESTED_PAGES === 'true' ? 'nested' : 'flat',
     formatting: 'prettify',
   },
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "example:single:dev": "npm -C examples/single-page run dev",
     "example:single:build": "npm -C examples/single-page run build",
     "example:single:serve": "npm -C examples/single-page run serve",
-    "test": "pnpm -r --filter=\"./examples/*\" build && vitest run",
+    "test": "pnpm -r --filter=\"./examples/*\" build && pnpm -C examples/multiple-pages-with-store run build:nested && vitest run",
     "build": "unbuild",
     "prepublishOnly": "npm run build",
     "typecheck": "vue-tsc --noEmit",

--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -6,7 +6,7 @@ import type { SSRContext } from 'vue/server-renderer'
 import type { ViteSSGContext, ViteSSGOptions } from '../types'
 import { existsSync } from 'node:fs'
 import fs from 'node:fs/promises'
-import { dirname, isAbsolute, parse, resolve } from 'node:path'
+import { dirname, isAbsolute, join, parse, resolve } from 'node:path'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
 import { renderDOMHead } from '@unhead/dom'
@@ -197,7 +197,7 @@ export async function build(ssgOptions: Partial<ViteSSGOptions> = {}, viteConfig
           : route).replace(/^\//g, '')}.html`
 
         const filename = dirStyle === 'nested'
-          ? resolve(route.replace(/^\//g, ''), 'index.html')
+          ? join(route.replace(/^\//g, ''), 'index.html')
           : relativeRouteFile
 
         await fs.mkdir(resolve(out, dirname(filename)), { recursive: true })

--- a/test/asset.test.ts
+++ b/test/asset.test.ts
@@ -22,3 +22,19 @@ describe('multiple-pages', () => {
     expect(file).toContain('Page A')
   })
 })
+
+describe('multiple-pages-with-store', () => {
+  it('routes are nested', async () => {
+    const files = await glob('**/*.html', {
+      cwd: 'examples/multiple-pages-with-store/dist',
+    })
+    expect(files).toMatchInlineSnapshot(`
+      [
+        "index.html",
+        "a/index.html",
+        "b/index.html",
+        "nested/deep/b/index.html",
+      ]
+    `)
+  })
+})


### PR DESCRIPTION

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR just uses the original `join` as suggested in the linked issue, adding a test using `examples/multiple-pages-with-store`.

### Linked Issues

resolves #454

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
